### PR TITLE
イベントBをいつでも使えるように変更（空イベントデータ）

### DIFF
--- a/mongo/scripts/events.js
+++ b/mongo/scripts/events.js
@@ -104,25 +104,25 @@ db.events.insert({
     Eventid: "2",
     Eventname: "イベントB",
     Overview: "イベントBの説明です",
-    Password: "password",
+    Password: "",
     Address: "test@example.com",
     displayName: "test",
-    Fieldid: "hard",
-    Venue: "ホワイエ",
+    Fieldid: "it",
+    Venue: "南館1階B教室",
     Holdperiod: {
-        Holdstart: "2016/10/21 9:00",
-        Holdfinish: "2016/10/23 15:00"
+        Holdstart: "2016/4/01 0:00",
+        Holdfinish: "2018/12/31 0:00"
     },
     Createperiod: {
-        Createstart: "2016/10/12 9:00",
-        Createfinish: "2016/10/20 12:00"
+        Createstart: "2016/4/01 0:00",
+        Createfinish: "2018/12/31 0:00"
     },
     Voteperiod: {
-        Votestart: "2016/10/21 9:00",
-        Votefinish: "2016/10/31 12:00"
+        Votestart: "2016/4/01 0:00",
+        Votefinish: "2018/12/31 0:00"
     },
-    Image: "public/images/goripic/drinkgori.png",
-    Order: ['5']
+    Image: "public/images/noimage.png",
+    Order: ['2', '3', '6', '1', '5']
 });
 db.events.insert({
     Eventid: "3",

--- a/mongo/scripts/teams.js
+++ b/mongo/scripts/teams.js
@@ -56,7 +56,7 @@ db.teams.insert({
 });
 db.teams.insert({
     Teamid:"4",
-    Eventid:"2",
+    Eventid:"3",
     Teamname:"PARM",
     Workname:"Dチームの作品",
     Overview   :"概要",

--- a/web/vars-server/routes/teamcreate.js
+++ b/web/vars-server/routes/teamcreate.js
@@ -79,7 +79,7 @@ router.post('/', upload.single('thumbnail'), function (req, res) {
               imagepath="public/images/noimage.png"  //NoImageのPathをここに格納
             }
           //発表順はとりあえず連番で取得する
-            getTeam.getTeam(eventid).then(function(docs){
+            getTeam.getTeamjson({Eventid:eventid}).then(function(docs){
                 order = docs.length++;
                 // 送る値をJSON形式で記述
                 const TEAMS = {
@@ -93,7 +93,7 @@ router.post('/', upload.single('thumbnail'), function (req, res) {
                     'Image'       :imagepath,
                     'Works'       :works,
                     'Department' :department,
-                    'Order'         :0
+                    'Order'         :order
                 };
 
                 insertTeam.insertTeam(TEAMS);   //チーム作成

--- a/web/vars-server/routes/vote.js
+++ b/web/vars-server/routes/vote.js
@@ -74,6 +74,7 @@ router.get('/', PasswordCheck, function (req, res) {
                                     if (!err) {
                                         var teamdata = new Array();
                                         var teams = [];
+                                        var teamerr=true;
                                         //投票部門に入っているチームの取り出し（async）
                                         async.eachSeries(votedata, function (vote, callback1) {
                                             teams = [];
@@ -96,33 +97,42 @@ router.get('/', PasswordCheck, function (req, res) {
                                                 })
                                             }, function (err) {
                                                 if (!err) {
-                                                    //console.log("teams:"+teams)
-                                                    teamdata[teamdata.length] = new Array();
-                                                    console.log("teamdata.length" + teamdata.length);
-                                                    teamdata[teamdata.length - 1] = teams;
-                                                    //console.log("teamdata.test:"+teamdata[teamdata.length - 1])
-                                                    callback1();
+                                                    if(teams.length>0) {
+                                                        //console.log("teams:"+teams)
+                                                        teamdata[teamdata.length] = new Array();
+                                                        console.log("teamdata.length" + teamdata.length);
+                                                        teamdata[teamdata.length - 1] = teams;
+                                                        //console.log("teamdata.test:"+teamdata[teamdata.length - 1])
+                                                        callback1();
+                                                    }else{
+                                                        teamerr=false;
+                                                        callback1();
+                                                    }
                                                 } else {
                                                     callback1();
                                                 }
                                             });
                                             //ループ終了した後
                                         }, function (err) {
-                                            console.log(typeof(teamdata[0][0]));
-                                            for (var cnt1 in teamdata) {
-                                                console.log(votedata[cnt1].Votename);
-                                                for (var cnt2 in teamdata[cnt1]) {
-                                                    //console.log("teamdata["+cnt1+"]["+cnt2+"]仕上げ:" + teamdata[cnt1][cnt2]);
+                                            if(teamerr) {
+                                                console.log(typeof(teamdata[0][0]));
+                                                for (var cnt1 in teamdata) {
+                                                    console.log(votedata[cnt1].Votename);
+                                                    for (var cnt2 in teamdata[cnt1]) {
+                                                        //console.log("teamdata["+cnt1+"]["+cnt2+"]仕上げ:" + teamdata[cnt1][cnt2]);
 
+                                                    }
                                                 }
+                                                res.render('vote.ejs', {
+                                                    eventdata: eventid,
+                                                    allteamdata: allteamdata,
+                                                    teamdata: teamdata,
+                                                    votedata: votedata,
+                                                    msg: ""
+                                                });
+                                            }else{
+                                                res.render('errorconfirmation.ejs', {msg: "チームが設定されていない部門があります。", url: '/eventtop?eventid=' + eventid});
                                             }
-                                            res.render('vote.ejs', {
-                                                eventdata: eventid,
-                                                allteamdata: allteamdata,
-                                                teamdata: teamdata,
-                                                votedata: votedata,
-                                                msg: ""
-                                            });
                                         });
                                     }
                                 })


### PR DESCRIPTION
チーム作成でイベント内にチームがない場合に初期順番割り振り処理が失敗するバグを修正。
投票ページで投票部門内にチームがなかった場合にエラーページに飛ばす処理を追加。