### PR TITLE
イベント設定ページの日時バグを修正。

### DIFF
--- a/web/vars-server/routes/eventcontrol.js
+++ b/web/vars-server/routes/eventcontrol.js
@@ -59,12 +59,12 @@ router.get('/eventsetting', function(req, res) {
           var eventid=req.query.eventid;
           getEvent.getEvent(eventid).then(function (docs){      //イベントが存在しているか確認
               console.log("eventdata:"+docs);
-              var Holdfinish=moment.parsedate(docs[0].Holdperiod.Holdfinish,"YYYY/M/D HH:mm");
-              var Holdstart=moment.parsedate(docs[0].Holdperiod.Holdstart,"YYYY/M/D HH:mm");
-              var Createstart=moment.parsedate(docs[0].Createperiod.Createstart,"YYYY/M/D HH:mm");
-              var Createfinish=moment.parsedate(docs[0].Createperiod.Createfinish,"YYYY/M/D HH:mm");
-              var Votestart=moment.parsedate(docs[0].Voteperiod.Votestart,"YYYY/M/D HH:mm");
-              var Votefinish=moment.parsedate(docs[0].Voteperiod.Votefinish,"YYYY/M/D HH:mm");
+              var Holdfinish=moment.parsedate(docs[0].Holdperiod.Holdfinish,"YYYY/MM/DD HH:mm");
+              var Holdstart=moment.parsedate(docs[0].Holdperiod.Holdstart,"YYYY/MM/DD HH:mm");
+              var Createstart=moment.parsedate(docs[0].Createperiod.Createstart,"YYYY/MM/DD HH:mm");
+              var Createfinish=moment.parsedate(docs[0].Createperiod.Createfinish,"YYYY/MM/DD HH:mm");
+              var Votestart=moment.parsedate(docs[0].Voteperiod.Votestart,"YYYY/MM/DD HH:mm");
+              var Votefinish=moment.parsedate(docs[0].Voteperiod.Votefinish,"YYYY/MM/DD HH:mm");
               getField.getField().then(function (field) {    //分野取得
                   console.log("分野:" + field);
                   res.render('eventsetting.ejs',{

--- a/web/vars-server/routes/googlelogin.js
+++ b/web/vars-server/routes/googlelogin.js
@@ -31,9 +31,12 @@ router.get('/return',passport.authenticate('google', {failureRedirect: '/login' 
     var success=false;
     //ドメインがst.kobedenshi.ac.jpか確認
     getAdmin.getAdmin(address).then(function (docs){
-        if(docs.length>0&&docs[0].Admin_flag){              //データーベースから取得できているかつその行のDB内のAdmin_flagがTrueになっている時に限る
-            console.log("管理者ユーザーログイン成功")
-            req.session.user.admin=true;
+        if(docs.length>0){//データーベースから取得できている
+            if(docs[0].Admin_flag) {
+                console.log("管理者ユーザーログイン成功")
+                req.session.user.admin = true;
+            }
+            req.session.user.displayName=docs[0].Name;
             success=true;
         }else if(req.session.user.domain ==="st.kobedenshi.ac.jp"){
             console.log("一般ユーザーログイン成功");

--- a/web/vars-server/views/header.ejs
+++ b/web/vars-server/views/header.ejs
@@ -37,7 +37,6 @@
                             <li class="nav-menu">
                                 <a class="dropdown-toggle" data-toggle="dropdown" href="#">アカウント <b class="caret"></b></a>
                                 <ul class="dropdown-menu">
-                                    <li><a href="/account">アカウント設定</a></li>
                                     <li><a href="/logout">ログアウト</a></li>
                                 </ul>
                             </li>


### PR DESCRIPTION
外部ユーザーがログインできなかった問題を解決。
外部ユーザー・adminユーザーがログインした時に、Googleアカウントネームよりも、設定した名前が優先されるように変更。
ヘッダーのアカウント情報変更欄を削除。